### PR TITLE
Bugfix where clicking on SVG element causes error

### DIFF
--- a/DatePicker.js
+++ b/DatePicker.js
@@ -220,7 +220,7 @@ var DatePicker = function (properties) {
                         var node = e.target,
                             isInside;
                         isInside = el.contains(node);
-                        if (node.className.indexOf('sm-calendar-arrow') > -1) {
+                        if (typeof node.className === 'string' && node.className.indexOf('sm-calendar-arrow') > -1) {
                             isInside = true;
                         }
                         if (!isInside && datePicker.display() === 'block') {


### PR DESCRIPTION
Added a check that node.className is actually a string, which is not the case for SVG nodes.